### PR TITLE
Downgrade to rootpath==0.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ Faker>=15.2.0
 setuptools>=65.5.1
 PyYAML>=6.0
 python-dotenv>=0.21.0
-rootpath>=0.1.1
+rootpath==0.1.0
 environs>=9.5.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="swagger-coverage",
-    version="2.2.13",
+    version="3.0.0",
     author="Jamal Zeinalov",
     author_email="jamal.zeynalov@gmail.com",
     description='Python adapter for "swagger-coverage" tool',
@@ -24,7 +24,7 @@ setup(
         "setuptools>=65.5.1",
         "PyYAML>=6.0",
         "python-dotenv>=0.21.0",
-        "rootpath>=0.1.1",
+        "rootpath==0.1.0",
         "environs>=9.5.0",
 
     ],


### PR DESCRIPTION
Codecov has been removed from pypi, rootpath 0.1.1 depends on codecov. Version 0.1.0 does not have `codecov` dependency.