### PR TITLE
Add DEBUG_MODE option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ API_DOCS_TYPE="swagger"  # Note: "openapi" is default type of API docs
 API_DOCS_VERSION="2.0"  # Note: "3.0.0" is default version of API docs
 API_DOCS_FORMAT="yaml"  # Note: "json" is default format of API docs and output files
 API_COVERAGE_REPORTS_DISABLED=True  # Skip requests recording. No files will be saved to 'swagger-coverage-output' dir 
+DEBUG_MODE=True  # Enable debug mode. All commandline logs will be printed to console (False by default)
 
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="swagger-coverage",
-    version="3.0.0",
+    version="3.1.0",
     author="Jamal Zeinalov",
     author_email="jamal.zeynalov@gmail.com",
     description='Python adapter for "swagger-coverage" tool',

--- a/swagger_coverage_py/configs.py
+++ b/swagger_coverage_py/configs.py
@@ -10,3 +10,5 @@ API_DOCS_TYPE = env.str("API_DOCS_TYPE", default="openapi")  # "swagger"
 API_DOCS_VERSION = env.str("API_DOCS_VERSION", default="3.0.0")  # "2.0"
 API_DOCS_FORMAT = env.str("API_DOCS_FORMAT", default="json")  # "yaml"
 IS_DISABLED = env.bool("API_COVERAGE_REPORTS_DISABLED", default=False)  # If True then requests won't be recorded
+
+DEBUG_MODE = env.bool("DEBUG_MODE", default=False)  # Set to True to see commandline output

--- a/swagger_coverage_py/reporter.py
+++ b/swagger_coverage_py/reporter.py
@@ -2,16 +2,17 @@ import os
 import platform
 import re
 import shutil
+import subprocess
 from pathlib import Path
 
 import requests
 
-from swagger_coverage_py.configs import API_DOCS_FORMAT
+from swagger_coverage_py.configs import API_DOCS_FORMAT, DEBUG_MODE
 from swagger_coverage_py.docs_writers.api_doc_writer import write_api_doc_to_file
 
 
 class CoverageReporter:
-    def __init__(self, api_name: str, host: str, verify:bool = True):
+    def __init__(self, api_name: str, host: str, verify: bool = True):
         self.host = host
         self.verify = verify
         self.swagger_doc_file = f"swagger-doc-{api_name}.{API_DOCS_FORMAT}"
@@ -64,7 +65,10 @@ class CoverageReporter:
             command if platform.system() != "Windows" else command.replace("/", "\\")
         )
 
-        os.system(command)
+        # Suppress all output if not in debug mode
+        command = command + " > /dev/null 2>&1" if not DEBUG_MODE else command
+
+        subprocess.run(command, shell=True)
 
     def cleanup_input_files(self):
         shutil.rmtree(self.output_dir, ignore_errors=True)


### PR DESCRIPTION
All command line outputs are suppressed.
DEBUG_MODE option (environment variable) is added to enable outputs (see README.md)