### PR TITLE
Fix body property example key in recorded OpenAPI

### DIFF
--- a/swagger_coverage_py/results_writers/base_schemas_manager.py
+++ b/swagger_coverage_py/results_writers/base_schemas_manager.py
@@ -55,7 +55,7 @@ class ApiDocsManagerBase:
                         value = urllib.parse.unquote(str(v))
                     else:
                         value = v
-                    properties[k] = {k: value, "type": value_type}
+                    properties[k] = {"example": value, "type": value_type}
 
                 request_body: dict = {
                     "content": {


### PR DESCRIPTION
Body request properties were serialized with the field name as the nested example key (`{k: value, "type": ...}`), producing non-standard OpenAPI like `properties.product_type.product_type: income`. The Java analyzer (`swagger-coverage-commandline`) expects the value at `properties.<name>.example`, so it could not extract values for body enum fields and reported `Checked values: [null, ...]` even when tests sent real values.

Switch the key to the standard `example` so analyzers can read the value. Effect: PropertyValueConditionPredicate now correctly sees the sent values, flipping body enum-coverage rules from red to green.