### PR TITLE
Fix output dirs for base paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="swagger-coverage",
-    version="3.5.1",
+    version="3.5.2",
     author="Jamal Zeinalov",
     author_email="jamal.zeynalov@gmail.com",
     description='Python adapter for "swagger-coverage" tool',

--- a/swagger_coverage_py/reporter.py
+++ b/swagger_coverage_py/reporter.py
@@ -25,6 +25,8 @@ class CoverageReporter:
     def __get_output_dir(self):
         output_dir = "swagger-coverage-output"
         subdir = re.match(r"(^\w*)://(.*)", self.host).group(2)
+        if "/" in subdir:
+            subdir = subdir.replace("/", "-")
         return f"{output_dir}/{subdir}"
 
     def __get_ignored_paths_from_config(self) -> List[str]:
@@ -73,7 +75,7 @@ class CoverageReporter:
 
     def generate_report(self):
         inner_location = "swagger-coverage-commandline/bin/swagger-coverage-commandline"
-        
+
         cmd_path = os.path.join(os.path.dirname(__file__), inner_location)
         assert Path(
             cmd_path
@@ -87,14 +89,13 @@ class CoverageReporter:
         # Adjust the file paths for Windows
         if platform.system() == "Windows":
             command = [arg.replace("/", "\\") for arg in command]
-        
+
         # Suppress all output if not in debug mode
         if not DEBUG_MODE:
-            with open(os.devnull, 'w') as devnull:
+            with open(os.devnull, "w") as devnull:
                 subprocess.run(command, stdout=devnull, stderr=devnull)
         else:
             subprocess.run(command)
-
 
     def cleanup_input_files(self):
         shutil.rmtree(self.output_dir, ignore_errors=True)

--- a/swagger_coverage_py/results_writers/base_schemas_manager.py
+++ b/swagger_coverage_py/results_writers/base_schemas_manager.py
@@ -128,7 +128,10 @@ class ApiDocsManagerBase:
         return self._get_other_request_params(params_key="headers", params_in="header")
 
     def __get_output_subdir(self):
-        return re.match(r"(^\w*)://(.*)", self._uri.host).group(2)
+        subdir = re.match(r"(^\w*)://(.*)", self._uri.host).group(2)
+        if "/" in subdir:
+            subdir = subdir.replace("/", "-")
+        return subdir
 
     def write_schema(self):
         schema_dict = self._get_schema()


### PR DESCRIPTION
## Summary
- Normalize output subdirectory names when Swagger hosts include URL paths.
- Keep reporter and schema output paths consistent by replacing path separators with dashes.
- Bump package version to 3.5.2.

## Test plan
- `python3 -m pytest` (no tests collected)


Made with [Cursor](https://cursor.com)